### PR TITLE
Update MetaTags.php

### DIFF
--- a/src/MetaTags.php
+++ b/src/MetaTags.php
@@ -65,7 +65,7 @@ class MetaTags
      * @param string|null $image
      * @return object
      */
-    public function data(string $title = null, string $desc = null, string $url = null, string $image = null): ?object
+    public function data(string $title = null, string $desc = null, string $url = null, string $image = null): ?\stdClass
     {
         (!$title ?: $this->title = $title);
         (!$desc ?: $this->description = $desc);


### PR DESCRIPTION
O método data estava retornando stdClass mas estava marcado para retornar um object.
No CWP com Centos7 e PHP 7.1.31 estava acusando erro.